### PR TITLE
properly report unknown pi version

### DIFF
--- a/uart_control/uart_control
+++ b/uart_control/uart_control
@@ -69,8 +69,10 @@ get_pi_type() {
       echo 3
    elif is_pifour; then
       echo 4
-   else
+   elif is_pizero; then
       echo 0
+   else
+      echo "unknown"
    fi
 }
 


### PR DESCRIPTION
With this pull request, ```uart_control status``` will report ```Raspberry Pi : unknown``` if the detection of the model fails. Previously a failed detection was reported as Raspberry Pi Zero.
